### PR TITLE
feat(deploy): add dry-run mode to Cloud Run dev deploy scripts

### DIFF
--- a/infra/cloud-run/deploy-api-dev.sh
+++ b/infra/cloud-run/deploy-api-dev.sh
@@ -17,6 +17,14 @@ echo "SERVICE_NAME=${SERVICE_NAME}"
 echo "IMAGE_URI=${IMAGE_URI}"
 echo "SERVICE_ACCOUNT=${SERVICE_ACCOUNT}"
 
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  echo "[DRY RUN] gcloud auth configure-docker ${REGION}-docker.pkg.dev"
+  echo "[DRY RUN] docker build -f apps/api/Dockerfile -t ${IMAGE_URI} ."
+  echo "[DRY RUN] docker push ${IMAGE_URI}"
+  echo "[DRY RUN] gcloud run deploy ${SERVICE_NAME} --image ${IMAGE_URI} --project ${PROJECT_ID} --region ${REGION} --platform managed --allow-unauthenticated --port 8080 --service-account ${SERVICE_ACCOUNT}"
+  exit 0
+fi
+
 gcloud auth configure-docker "${REGION}-docker.pkg.dev"
 
 docker build -f apps/api/Dockerfile -t "${IMAGE_URI}" .

--- a/infra/cloud-run/deploy-phone-gateway-dev.sh
+++ b/infra/cloud-run/deploy-phone-gateway-dev.sh
@@ -17,6 +17,14 @@ echo "SERVICE_NAME=${SERVICE_NAME}"
 echo "IMAGE_URI=${IMAGE_URI}"
 echo "SERVICE_ACCOUNT=${SERVICE_ACCOUNT}"
 
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  echo "[DRY RUN] gcloud auth configure-docker ${REGION}-docker.pkg.dev"
+  echo "[DRY RUN] docker build -f apps/phone-gateway/Dockerfile -t ${IMAGE_URI} ."
+  echo "[DRY RUN] docker push ${IMAGE_URI}"
+  echo "[DRY RUN] gcloud run deploy ${SERVICE_NAME} --image ${IMAGE_URI} --project ${PROJECT_ID} --region ${REGION} --platform managed --allow-unauthenticated --port 8080 --service-account ${SERVICE_ACCOUNT}"
+  exit 0
+fi
+
 gcloud auth configure-docker "${REGION}-docker.pkg.dev"
 
 docker build -f apps/phone-gateway/Dockerfile -t "${IMAGE_URI}" .


### PR DESCRIPTION
Ajoute un mode DRY_RUN=1 aux scripts :
- infra/cloud-run/deploy-api-dev.sh
- infra/cloud-run/deploy-phone-gateway-dev.sh

Validation faite :
- dry-run API OK
- dry-run phone-gateway OK
- aucune commande cloud/docker réelle exécutée

But :
valider les commandes de déploiement DEV sans toucher au service en ligne actuel.